### PR TITLE
fix

### DIFF
--- a/src/vkapi.js
+++ b/src/vkapi.js
@@ -208,7 +208,7 @@ class VkApi {
         // Return full response object, because it 
         // can contain "execute_errors" array which 
         // is important when "execute" method is called.
-        if (method === 'execute' || /^execute\./i.test(method)) {
+        if (method === 'execute' || method.startsWith('execute.')) {
           return response;
         }
 

--- a/src/vkapi.js
+++ b/src/vkapi.js
@@ -208,7 +208,7 @@ class VkApi {
         // Return full response object, because it 
         // can contain "execute_errors" array which 
         // is important when "execute" method is called.
-        if (method === 'execute') {
+        if (method === 'execute' || /^execute\./i.test(method)) {
           return response;
         }
 


### PR DESCRIPTION
С помощью метода execcute можно вызывать также функции, которые сохранены в настройках приложения. В таком случает метод приобретает такой вид - "execute.НАЗВАНИЕ_ФУНКЦИИ". В коде библиотеки это не учитвается

![image](https://user-images.githubusercontent.com/9965996/31828678-9cfefbe2-b5c3-11e7-811d-41c0e3d8b681.png)
