### PR TITLE
Веб авторизация в заблокированную страницу

### DIFF
--- a/src/vkapi.js
+++ b/src/vkapi.js
@@ -301,12 +301,18 @@ class VkApi {
         return response.text()
           .then(body => {
             const $          = cheerio.load(body);
-            const errorBlock = $('.service_msg_warning');
+            const loginErrorBlock   = $('.service_msg_warning');
+            const blockedErrorBlock = $('.login_blocked_panel');
 
-            if (errorBlock.length) {
+            if (loginErrorBlock.length) {
               throw new VkAuthError({
                 error:             'web_login_error',
-                error_description: errorBlock.text()
+                error_description: loginErrorBlock.text()
+              });
+            } else if (blockedErrorBlock.length) {
+              throw new VkAuthError({
+                error:             'web_login_error',
+                error_description: 'User is temporary blocked.'
               });
             }
 


### PR DESCRIPTION
Если страница временно заблокирована, например, за спам, то при попытке авторизоваться по логину и паролю, выпадает это:
```
Error: only absolute urls are supported
    at C:\test\node_modules\node-fetch\index.js:54:10
    at new Promise (<anonymous>)
    at new Fetch (C:\test\node_modules\node-fetch\index.js:49:9)
    at Fetch (C:\test\node_modules\node-fetch\index.js:37:10)
    at fetchWithAutoRetry (C:\test\node_modules\node-vkapi\src\lib\fetch.js:40:10)
    at C:\test\node_modules\fetch-cookie\index.js:16:16
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```
Добавил на этот случай генерацию исключения по аналогии с обработкой неверного логина и пароля.